### PR TITLE
Feedly's subscription point was changed

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -13,7 +13,7 @@ const URI_KEY = ".uri";
 
 const TITLE_VAL = "Feedly Cloud";
 const TYPE_VAL = "application/vnd.mozilla.maybe.feed";
-const URI_VAL = "https://cloud.feedly.com/#subscription/feed/%s"
+const URI_VAL = "https://feedly.com/i/spotlight/%s"
 
 const AUTO_KEY = "browser.contentHandlers.auto.application/vnd.mozilla.maybe.feed";
 


### PR DESCRIPTION
For me subscription to Feedly even stopped working for a while. Seems like they've set up redirect correctly now, but I think we can't rely on the redirect and it slightly slows down subscription of course.
